### PR TITLE
RemoveDefer & typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+import { type WebpackPluginInstance } from 'webpack';
+
+declare module "html-webpack-plugin" {
+  declare namespace HtmlWebpackPlugin {
+    interface Options {
+      chunksConfig: {
+        async: string[],
+        defer: string[],
+        removeDefer: string[],
+      }
+    }
+  }
+}
+
+class HtmlWebpackInjectorPlugin implements WebpackPluginInstance { }
+
+module.exports = HtmlWebpackInjectorPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,19 @@
-import { type WebpackPluginInstance } from 'webpack';
+import { Compiler, WebpackPluginInstance } from 'webpack';
+import { } from 'html-webpack-plugin';
 
-declare module "html-webpack-plugin" {
-  declare namespace HtmlWebpackPlugin {
-    interface Options {
-      chunksConfig: {
-        async: string[],
-        defer: string[],
-        removeDefer: string[],
-      }
-    }
+declare module 'html-webpack-plugin' {
+  export interface Options extends InjectorOptions { }
+}
+
+export interface InjectorOptions {
+  chunksConfig?: {
+    async?: string[],
+    defer?: string[],
+    removeDefer?: string[],
   }
 }
 
-class HtmlWebpackInjectorPlugin implements WebpackPluginInstance { }
-
-module.exports = HtmlWebpackInjectorPlugin;
+export default class HtmlWebpackInjectorPlugin implements WebpackPluginInstance {
+  [index: string]: any;
+  apply: (compiler: Compiler) => void;
+}

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ function handleChunksConfig(data, tags) {
   if (data.plugin.options.chunksConfig) {
     const asyncNames = data.plugin.options.chunksConfig.async;
     const deferNames = data.plugin.options.chunksConfig.defer;
+    const removeDeferNames = data.plugin.options.chunksConfig.removeDefer;
 
     if(asyncNames && typeof asyncNames === "object" && asyncNames.length){
       tags.forEach(tag => {
@@ -46,6 +47,17 @@ function handleChunksConfig(data, tags) {
         if (!tag.attributes.href && tag.attributes.src) {
           deferNames.forEach(name => {
             addAttributesToTag(tag, name, {defer: true});
+          })
+        }
+      });
+    }
+
+    if(removeDeferNames && typeof removeDeferNames === "object" && removeDeferNames.length){
+      tags.forEach(tag => {
+        // add defer only on script tags.
+        if (!tag.attributes.href && tag.attributes.src) {
+          removeDeferNames.forEach(name => {
+            addAttributesToTag(tag, name, {defer: false});
           })
         }
       });


### PR DESCRIPTION
I added an option called 'removeDefer' which removes the defer tag.
This is useful if you set the `scriptLoading: 'defer',` option on the HtmlWebpackPlugin, as this way, you can have:

```
new HtmlWebpackPlugin({
    // Defer script loading for faster loading
    scriptLoading: 'defer',
    chunksConfig: {
        async: ["MyAsyncEntry"],
        removeDefer: ["MyAsyncEntry"],
    },
}),
```
And then `MyAsyncEntry` will only have `async="async"` as an attribute, and no longer will have `defer="defer"` as well.


I also added a typescript d.ts file, which augments the HtmlWebpackPlugin options to provide the types.
Useful if you have your webpack files in typescript (like I do).